### PR TITLE
Pre-release v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Change Log
 
+## [v0.2.2](https://github.com/usmanmehmood55/c-toolkit/releases/tag/0.2.1)
+
+### Improvements
+
+- IntelliSense settings now have the correct GCC path.
+- Added [Busybox](https://busybox.net/) to installation tools on Windows
+  to access common Unix tools.
+
+### Fixes
+
+- On Windows, if the username had a space in it, eg `John Doe` instead of
+  `JohnDoe` or `j.doe`, Scoop would not be detected, and any tools installed
+  by Scoop would also not be detected. This has been fixed.
+
+### Known Issues
+
+- Extension doesn't activate when a folder isn't open in the workspace.
+
 ## [v0.2.1](https://github.com/usmanmehmood55/c-toolkit/releases/tag/0.2.1)
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Change Log
 
+## [v0.2.1](https://github.com/usmanmehmood55/c-toolkit/releases/tag/0.2.1)
+
+### Features
+
+- Extension icon updated.
+- Added git to installation tools.
+
+### Improvements
+
+- Added special cases in file and code generation for MacOS.
+- Default build type set to Debug.
+- Test build type also added in selection button.
+- User can now provide sudo password for tool installation on Linux.
+- Improved logs.
+
+### Fixes
+
+- Used LLDB instead GDB on MacOS, debugging works on MacOS now.
+- Fixed tools installation on Linux.
+- Scoop detection failing on systems with spaces in account username.
+
+### Known Issues
+
+- Extension doesn't activate when a folder isn't open in the workspace.
+
 ## [v0.1.3](https://github.com/usmanmehmood55/c-toolkit/releases/tag/0.1.3)
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "publisher": "UsmanMehmood",
     "displayName": "C Toolkit",
     "description": "Creates, builds and runs C applications using CMake",
-    "version": "0.2.1",
+    "version": "0.2.2",
     "icon": "images/icon.png",
     "repository": {
         "type": "git",

--- a/source/ButtonActions.js
+++ b/source/ButtonActions.js
@@ -210,6 +210,8 @@ async function invokeBuild(buildState)
         // wait until build has completed
     }
 
+    if (fs.existsSync(BUILD_MARKER_PATH)) fs.rmSync(BUILD_MARKER_PATH);
+
     delay(10); // wese hi
 }
 

--- a/source/FileContents.js
+++ b/source/FileContents.js
@@ -13,13 +13,6 @@ const LaunchJsonMiMode =
     [utils.OsTypes.MACOS]   : 'lldb',
 };
 
-const CPropsJsonGccPath = 
-{
-    [utils.OsTypes.WINDOWS] : 'C:/Users/u.mehmood/scoop/apps/gcc/current/bin/gcc',
-    [utils.OsTypes.LINUX]   : '/usr/bin/gcc',
-    [utils.OsTypes.MACOS]   : '/usr/bin/gcc',
-};
-
 const intelliSenseMode = 
 {
     [utils.OsTypes.WINDOWS] : 'windows-gcc-x64',
@@ -319,6 +312,8 @@ function ProjectCmake()
  */
 function CppPropertiesJson()
 {
+    const gccPath = utils.FindProgramPath('gcc');
+
     let content =
     
     "{"                                                                             + "\n" +
@@ -327,7 +322,7 @@ function CppPropertiesJson()
     "        {"                                                                     + "\n" +
     "            \"name\"            : \"c-toolkit config\","                       + "\n" +
     "            \"includePath\"     : [ \"${workspaceFolder}/**\" ],"              + "\n" +
-    `            \"compilerPath\"    : \"${CPropsJsonGccPath[utils.CheckOs()]}\",`  + "\n" +
+    `            \"compilerPath\"    : \"${gccPath}\",`                             + "\n" +
     "            \"cStandard\"       : \"c11\","                                    + "\n" +
     "            \"cppStandard\"     : \"c++11\","                                  + "\n" +
     `            \"intelliSenseMode\": \"${intelliSenseMode[utils.CheckOs()]}\",`   + "\n" +

--- a/source/ToolsManager.js
+++ b/source/ToolsManager.js
@@ -16,6 +16,7 @@ const BuildTools =
     MAKE  : 'make',
     SCOOP : 'scoop',
     GIT   : 'git',
+    BBOX  : 'busybox',
 };
 
 const PackageManagers = 
@@ -36,6 +37,8 @@ async function isToolInPath(toolName)
 {
     toolName = toolName === BuildTools.SCOOP ? `${utils.WrapSpacedComponents(os.homedir())}\\scoop\\shims\\scoop` : toolName;
     
+    // Busybox does not support '--version' argument so this case ahs been added for it
+    const versionCommand = toolName === BuildTools.BBOX ? toolName : `${toolName} --version`;
 
     try
     {
@@ -396,10 +399,8 @@ async function searchForTools()
     }
 
     let toolsToCheck = [BuildTools.GCC, BuildTools.CMAKE, BuildTools.NINJA, BuildTools.MAKE, BuildTools.GIT];
-    if (utils.CheckOs() !== utils.OsTypes.MACOS) 
-    {
-        toolsToCheck.push(BuildTools.GDB);
-    }
+    if (utils.CheckOs() !== utils.OsTypes.MACOS) toolsToCheck.push(BuildTools.GDB);
+    if (utils.CheckOs() === utils.OsTypes.WINDOWS) toolsToCheck.push(BuildTools.BBOX);
 
     let results = await Promise.all(toolsToCheck.map(tool => isToolInPath(tool)));
 

--- a/source/ToolsManager.js
+++ b/source/ToolsManager.js
@@ -1,7 +1,8 @@
 const vscode = require('vscode');
 const os     = require('os');
 const utils  = require('./Utils');
-const { exec, spawn, spawnSync } = require('child_process');
+const { spawn, spawnSync } = require('child_process');
+const { execSync } = require('child_process');
 
 /**
  * Enum for build tools required
@@ -34,21 +35,17 @@ const PackageManagers =
 async function isToolInPath(toolName)
 {
     toolName = toolName === BuildTools.SCOOP ? `${utils.WrapSpacedComponents(os.homedir())}\\scoop\\shims\\scoop` : toolName;
-    return new Promise((resolve, reject) => 
+    
+
+    try
     {
-        exec(`${toolName} --version`, (error, stdout, stderr) => 
-        {
-            if (error) 
-            {
-                resolve(false);
-            }
-            else
-            {
-                resolve(true);
-            }
-            console.log(`isToolInPath - error: ${error}, stdout: ${stdout}, stderr: ${stderr}`);
-        });
-    });
+        execSync(versionCommand, { stdio: 'ignore' });
+        return true;
+    }
+    catch (error)
+    {
+        return false;
+    }
 }
 
 /**
@@ -143,7 +140,7 @@ function execCommand(userPassword, command, args)
     if (command === 'scoop')
     {
         command = 'cmd';
-        args = ['/c', 'scoop', ...args];
+        args = ['/c', `${utils.WrapSpacedComponents(os.homedir())}\\scoop\\shims\\scoop`, ...args];
     }
 
     console.log(`execCommand - Executing: ${command} ${args.join(' ')}`);

--- a/source/Utils.js
+++ b/source/Utils.js
@@ -1,6 +1,7 @@
 const os     = require('os');
 const vscode = require('vscode');
 const path   = require('path');
+const { execSync } = require('child_process');
 
 /**
  * Enum for OS types
@@ -94,11 +95,32 @@ function SanitizeFileName(name)
     return invalidRemoved;
 }
 
+/**
+ * Finds the path of the given program using the 'which' command.
+ * 
+ * @param {string} program The program to find.
+ * 
+ * @returns {string | undefined} The path to the program or undefined if not found.
+ */
+function FindProgramPath(program)
+{
+    try
+    {
+        const path = execSync(`which ${program}`, { encoding: 'utf-8' }).trim();
+        return path;
+    }
+    catch (error)
+    {
+        return undefined;
+    }
+}
+
 module.exports =
 {
     FormatList,
     SanitizeFileName,
     OsTypes,
     CheckOs,
-    WrapSpacedComponents
+    WrapSpacedComponents,
+    FindProgramPath,
 };


### PR DESCRIPTION
### Improvements

- IntelliSense settings now have the correct GCC path.
- Added [Busybox](https://busybox.net/) to installation tools on Windows
  to access common Unix tools.

### Fixes

- On Windows, if the username had a space in it, eg `John Doe` instead of
  `JohnDoe` or `j.doe`, Scoop would not be detected, and any tools installed
  by Scoop would also not be detected. This has been fixed.