### PR TITLE
Release v2.0 🎉

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Change Log
 
+## [v2.0.0](https://github.com/usmanmehmood55/c-toolkit/releases/tag/2.0.0)
+
+### Info
+
+All changes between v1.0.0 and v1.1.2 are combined into this release, v2.0.0.
+
+## [v1.1.2](https://github.com/usmanmehmood55/c-toolkit/releases/tag/1.1.2)
+
+### Improvements
+
+- Change of name, extension is now "C C++ Toolkit".
+- Added relevant categories and keywords in `package.json`.
+
 ## [v1.1.0](https://github.com/usmanmehmood55/c-toolkit/releases/tag/1.1.0)
 
 ### Features
@@ -18,6 +31,12 @@
 - When a component is created with its test and mock files, the header comments would
   indicate source files as header files. E.g., a comment in `mock_comment.c` would
   say that the file is `mock_comment.h`. This has been fixed.
+
+## [v1.0.0](https://github.com/usmanmehmood55/c-toolkit/releases/tag/1.0.0)
+
+### Info
+
+All changes between v0.0.1 and v0.2.4 are combined into this release, v1.0.0.
 
 ## [v0.2.4](https://github.com/usmanmehmood55/c-toolkit/releases/tag/0.2.4)
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "publisher": "UsmanMehmood",
     "displayName": "C C++ Toolkit",
     "description": "Create, compile and run C and C++ applications easily using CMake. The only C/C++ code runner you'll need!",
-    "version": "1.1.1",
+    "version": "2.0.0",
     "icon": "images/icon.png",
     "repository": {
         "type": "git",
@@ -78,5 +78,30 @@
     "directories": {
         "test": "test"
     },
-    "author": "Usman Mehmood"
+    "author": "Usman Mehmood",
+    "tags": [
+        "c",
+        "c++",
+        "run",
+        "compile",
+        "build",
+        "debug"
+    ],
+    "keywords": [
+        "C",
+        "C++",
+        "code runner",
+        "build",
+        "debug",
+        "compiler",
+        "cmake",
+        "gcc",
+        "gdb",
+        "programming",
+        "development",
+        "testing",
+        "embedded",
+        "project generator",
+        "code generator"
+    ]
 }


### PR DESCRIPTION
### Features

- C++ support! User can now create C++ projects and components.
- The extension automatically the project type when it is opened in VS Code.

### Improvements

- Change of name, extension is now "C C++ Toolkit".
- When a component is created with its test files, `component.h` is also now included
  in `test_component.c`. Previously only `test_component.h` was included.

### Fixes

- When a component is created with its test and mock files, the header comments would
  indicate source files as header files. E.g., a comment in `mock_comment.c` would
  say that the file is `mock_comment.h`. This has been fixed.