### PR TITLE
Release v2.0.4

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -7,8 +7,33 @@ on:
       - pre_release
 
 jobs:
+  validate_tokens:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check VSCE_PUBLISH_PAT validity
+        run: |
+          echo "Checking VSCE_PUBLISH_PAT..."
+          if ! vsce ls-publishers -p ${{ secrets.VSCE_PUBLISH_PAT }}; then
+            echo "VSCE_PUBLISH_PAT is invalid or expired."
+            exit 1
+          else
+            echo "VSCE_PUBLISH_PAT is valid."
+          fi
+
+      - name: Check PERSONAL_ACCESS_TOKEN validity
+        run: |
+          echo "Checking PERSONAL_ACCESS_TOKEN..."
+          response=$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: token ${{ secrets.PERSONAL_ACCESS_TOKEN }}" https://api.github.com/user)
+          if [ "$response" -ne 200 ]; then
+            echo "PERSONAL_ACCESS_TOKEN is invalid or expired."
+            exit 1
+          else
+            echo "PERSONAL_ACCESS_TOKEN is valid."
+          fi
+
   build_and_release:
     runs-on: ubuntu-latest
+    needs  : validate_tokens
     if     : github.event.head_commit.author.email != 'github-actions[bot]@users.noreply.github.com'
     outputs: 
       isPrerelease: ${{ steps.set_prerelease.outputs.isPrerelease }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Change Log
 
+## [v2.0.4](https://github.com/usmanmehmood55/c-toolkit/releases/tag/2.0.4)
+
+### Improvements
+
+- The run button does not perform a clean build before running. The decision to
+  clean the build is now left to the user, by using the "clean" button.
+- Added PAT validations to GitHub workflow.  
+
+### Fixes
+
+- The build marker file is now properly created and deleted, previously it was
+  sometimes causing this error message: "`EBUSY: resource busy or locked, unlink
+  <project_folder>\build\z_build_complete`".
+
 ## [v2.0.3](https://github.com/usmanmehmood55/c-toolkit/releases/tag/2.0.3)
 
 ### Improvements

--- a/extension.js
+++ b/extension.js
@@ -96,7 +96,7 @@ function createStatusBarItem(button, context)
         /** @returns {Promise<void>} */
         "Build"     : () => buttonActions.invokeBuild(buildState),
         /** @returns {Promise<void>} */
-        "Run"       : () => buttonActions.invokeRun(buildState, true),
+        "Run"       : () => buttonActions.invokeRun(buildState, false),
         /** @returns {Promise<void>} */
         "Debug"     : () => buttonActions.invokeDebug(buildState),
         /** @returns {Promise<void>} */

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "publisher": "UsmanMehmood",
     "displayName": "C C++ Toolkit",
     "description": "Create, compile and run C and C++ applications easily using CMake. The only C/C++ code runner you'll need!",
-    "version": "2.0.3",
+    "version": "2.0.4",
     "icon": "images/icon.png",
     "repository": {
         "type": "git",
@@ -88,8 +88,8 @@
         "debug"
     ],
     "keywords": [
-        "C",
-        "C++",
+        "c",
+        "c++",
         "code runner",
         "build",
         "debug",


### PR DESCRIPTION
### Improvements

- The run button does not perform a clean build before running. The decision to
  clean the build is now left to the user, by using the "clean" button.
- Added PAT validations to GitHub workflow.  

### Fixes

- The build marker file is now properly created and deleted, previously it was
  sometimes causing this error message: "`EBUSY: resource busy or locked, unlink
  <project_folder>\build\z_build_complete`".